### PR TITLE
Improve KEYINFO runtime config

### DIFF
--- a/tests/unit/keyinfo.tcl
+++ b/tests/unit/keyinfo.tcl
@@ -116,4 +116,27 @@ start_server {tags {"keyinfo"} overrides {keyinfo-num-elements-larger-than 2 key
         r zrem key-zset m3
         assert_equal [r keyinfo len many-elements] 0
     }
+
+    test {KEYINFO - runtime configuration of threshold works} {
+        r keyinfo reset many-elements
+        r config set keyinfo-num-elements-larger-than 5
+        r set dynkey abcde
+        assert_equal [r keyinfo len many-elements] 0
+        r config set keyinfo-num-elements-larger-than 4
+        r set dynkey abcde
+        assert_equal [r keyinfo len many-elements] 1
+    }
+
+    test {KEYINFO - resizing max length at runtime keeps existing entries} {
+        r keyinfo reset many-elements
+        r config set keyinfo-large-num-elements-max-len 2
+        r set k1 123
+        r set k2 123
+        assert_equal [r keyinfo len many-elements] 2
+        r config set keyinfo-large-num-elements-max-len 4
+        assert_equal [r keyinfo len many-elements] 2
+        r set k3 123
+        r set k4 123
+        assert_equal [r keyinfo len many-elements] 4
+    }
 }

--- a/valkey.conf
+++ b/valkey.conf
@@ -2103,6 +2103,9 @@ keyinfo-num-elements-larger-than 1024
 # specific entry based on the hash of the key. When two or more keys generate the
 # same hash value (hash collision), the previous entry is overwritten by the new one.
 keyinfo-large-num-elements-max-len 128
+# Both options are CONFIG SET-able and can be changed on the fly
+# while Valkey is running, allowing KEYINFO to be enabled or disabled
+# without a restart.
 
 ################################ LATENCY MONITOR ##############################
 


### PR DESCRIPTION
## Summary
- note in `valkey.conf` that KEYINFO options can be changed using `CONFIG SET`
- add tests for changing KEYINFO threshold and list size while the server is running

## Testing
- `./runtest --single unit/keyinfo --verbose` *(fails: Cleanup and startup messages only)*

------
https://chatgpt.com/codex/tasks/task_e_6848927d95508325909a3634b03517b3